### PR TITLE
[codex] frontmatter対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .build
 .vscode
+.claude
 Package.resolved
 
 # Xcode

--- a/MarkdownViewer/MarkdownWebView.swift
+++ b/MarkdownViewer/MarkdownWebView.swift
@@ -110,6 +110,17 @@ struct MarkdownWebView: NSViewRepresentable {
             text-align: center;
             margin: 1em 0;
         }
+        .frontmatter {
+            background-color: #f7f0ff;
+            border: 1px solid #eadcff;
+            border-radius: 6px;
+            color: #5f4b8b;
+            font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+            font-size: 0.9em;
+            margin: 0 0 24px 0;
+            padding: 16px;
+            white-space: pre-wrap;
+        }
         .changed {
             background-color: #fff5b1;
             border-radius: 3px;
@@ -138,7 +149,6 @@ struct MarkdownWebView: NSViewRepresentable {
             if let yOffset = result as? CGFloat {
                 context.coordinator.savedScrollPosition = CGPoint(x: 0, y: yOffset)
             }
-            
             // メインスレッドでHTMLをロード
             DispatchQueue.main.async {
                 let (html, baseURL) = self.renderMarkdownToHTML(self.markdown, changedLines: self.changedLines)
@@ -153,7 +163,7 @@ struct MarkdownWebView: NSViewRepresentable {
     
     class Coordinator: NSObject, WKNavigationDelegate {
         var savedScrollPosition: CGPoint?
-        
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Navigation completed successfully - スクロール位置を復元
             if let position = savedScrollPosition {
@@ -268,12 +278,16 @@ struct MarkdownWebView: NSViewRepresentable {
     }
 
     private func renderMarkdownToHTML(_ markdown: String, changedLines: Set<Int>) -> (String, URL?) {
+        let (frontmatter, markdownBody) = FrontmatterRenderer.split(markdown)
+
         // Markdownをパースしてhtml生成
-        let document = Document(parsing: markdown)
+        let document = Document(parsing: markdownBody)
         var formatter = HTMLFormatter(changedLines: changedLines)
         formatter.visit(document)
         let htmlContent = formatter.result
         let hasMermaid = formatter.hasMermaid
+        let frontmatterHTML = frontmatter.map(FrontmatterRenderer.html(for:)) ?? ""
+        let contentSections = [frontmatterHTML, htmlContent].filter { !$0.isEmpty }
 
         // baseURLを設定（リソースを読み込むため）
         let baseURL: URL? = {
@@ -282,9 +296,46 @@ struct MarkdownWebView: NSViewRepresentable {
         }()
 
         // 完全なHTMLドキュメントを構築
-        let html = buildHTMLDocument(content: htmlContent, mermaidEnabled: hasMermaid)
+        let html = buildHTMLDocument(content: contentSections.joined(separator: "\n"), mermaidEnabled: hasMermaid)
 
         return (html, baseURL)
+    }
+}
+
+enum FrontmatterRenderer {
+    static func split(_ markdown: String) -> (frontmatter: String?, body: String) {
+        guard let firstLineRange = nextLineRange(in: markdown, startingAt: markdown.startIndex),
+              String(markdown[firstLineRange]).trimmingCharacters(in: .newlines) == "---" else {
+            return (nil, markdown)
+        }
+
+        var scanIndex = firstLineRange.upperBound
+
+        while let lineRange = nextLineRange(in: markdown, startingAt: scanIndex) {
+            let line = String(markdown[lineRange]).trimmingCharacters(in: .newlines)
+            if line == "---" || line == "..." {
+                let frontmatter = String(markdown[..<lineRange.upperBound])
+                let body = lineRange.upperBound < markdown.endIndex ? String(markdown[lineRange.upperBound...]) : ""
+                return (frontmatter, body)
+            }
+            scanIndex = lineRange.upperBound
+        }
+
+        return (nil, markdown)
+    }
+
+    static func html(for frontmatter: String) -> String {
+        "<pre class=\"frontmatter\">\(frontmatter.htmlEscaped)</pre>"
+    }
+
+    private static func nextLineRange(in string: String, startingAt index: String.Index) -> Range<String.Index>? {
+        guard index < string.endIndex else { return nil }
+
+        if let newlineIndex = string[index...].firstIndex(of: "\n") {
+            return index..<string.index(after: newlineIndex)
+        }
+
+        return index..<string.endIndex
     }
 }
 

--- a/Tests/MarkdownViewerTests/MarkdownViewerTests.swift
+++ b/Tests/MarkdownViewerTests/MarkdownViewerTests.swift
@@ -145,3 +145,60 @@ final class DiffCalculatorTests: XCTestCase {
         XCTAssertEqual(changes, [2, 4])
     }
 }
+final class FrontmatterRendererTests: XCTestCase {
+
+    func testSplitExtractsFrontmatterAtTop() {
+        let markdown = """
+        ---
+        title: Example
+        tags:
+          - swift
+        ---
+        # Heading
+        """
+
+        let parts = MarkdownViewer.FrontmatterRenderer.split(markdown)
+
+        XCTAssertEqual(parts.frontmatter, "---\ntitle: Example\ntags:\n  - swift\n---\n")
+        XCTAssertEqual(parts.body, "# Heading")
+    }
+
+    func testSplitSupportsDotsClosingDelimiter() {
+        let markdown = """
+        ---
+        title: Example
+        ...
+        Body
+        """
+
+        let parts = MarkdownViewer.FrontmatterRenderer.split(markdown)
+
+        XCTAssertEqual(parts.frontmatter, "---\ntitle: Example\n...\n")
+        XCTAssertEqual(parts.body, "Body")
+    }
+
+    func testSplitIgnoresHorizontalRuleOutsideFileStart() {
+        let markdown = """
+        # Heading
+        ---
+        Body
+        """
+
+        let parts = MarkdownViewer.FrontmatterRenderer.split(markdown)
+
+        XCTAssertNil(parts.frontmatter)
+        XCTAssertEqual(parts.body, markdown)
+    }
+
+    func testFrontmatterHTMLUsesDedicatedClassAndEscapesContent() {
+        let html = MarkdownViewer.FrontmatterRenderer.html(for: """
+        ---
+        title: <Example>
+        ---
+        """)
+
+        XCTAssertTrue(html.contains("<pre class=\"frontmatter\">"), html)
+        XCTAssertTrue(html.contains("title: &lt;Example&gt;"), html)
+        XCTAssertTrue(html.contains("---"), html)
+    }
+}


### PR DESCRIPTION
## 概要
- markdown ファイル先頭の frontmatter を検出して、本文とは別に表示するように変更
- frontmatter 部分を薄い紫背景・monospace フォントの `<pre>` として描画
- `.gitignore` に `.claude` を追加

## 変更内容
- `---` で始まる先頭 frontmatter を切り出して、本文は通常の Markdown としてレンダリング
- 終端は `---` と `...` の両方に対応
- frontmatter がファイル先頭にない場合は無視
- frontmatter 表示用のテストを追加

## 確認
- `swift test`
  - 14 件成功

## 関連
Closes #12
